### PR TITLE
a collection of changes while locally testing SQLite (and CSV, DataStreams)

### DIFF
--- a/REQUIRE
+++ b/REQUIRE
@@ -1,4 +1,5 @@
 julia 0.3-
 BinDeps
+Libz
 @osx Homebrew
 @windows WinRPM

--- a/REQUIRE
+++ b/REQUIRE
@@ -1,5 +1,6 @@
 julia 0.3-
 BinDeps
 Libz
+NullableArrays
 @osx Homebrew
 @windows WinRPM

--- a/deps/build.jl
+++ b/deps/build.jl
@@ -19,3 +19,6 @@ end
 end
 
 @BinDeps.install [:sqlite3_lib => :sqlite3_lib ]
+
+haskey(Pkg.installed(),"DataStreams") || Pkg.clone("https://github.com/quinnj/DataStreams.jl")
+# haskey(Pkg.installed(),"CSV") || Pkg.clone("https://github.com/quinnj/CSV.jl")

--- a/src/SQLite.jl
+++ b/src/SQLite.jl
@@ -284,6 +284,7 @@ function query(db::DB,sql::AbstractString, values=[])
         r, col = next(source,col)
         push!(results[c],r)
     end
+    close(source)
     return ResultSet(colnames, results)
 end
 

--- a/src/SQLite.jl
+++ b/src/SQLite.jl
@@ -53,7 +53,6 @@ type DB
         f = isempty(f) ? f : expanduser(f)
         if @OK sqliteopen(f,handlemem)
             db = new(f,handlemem[1],0)
-            register(db, regexp, nargs=2)
             finalizer(db, close)
             return db
         else # error
@@ -68,7 +67,7 @@ DB() = DB(":memory:")
 Base.show(io::IO, db::SQLite.DB) = print(io, string("SQLite.DB(",db.file == ":memory:" ? "in-memory" : "\"$(db.file)\"",")"))
 
 function close(db::DB)
-    @CHECK sqlite3_close(db.handle)
+    @CHECK db sqlite3_close(db.handle)
     nothing
 end
 

--- a/src/SQLite.jl
+++ b/src/SQLite.jl
@@ -97,14 +97,6 @@ function Base.close(stmt::Stmt)
     nothing
 end
 
-type Table
-    db::DB
-    name::AbstractString
-end
-
-include("UDF.jl")
-export @sr_str, @register, register
-
 # bind a row to nameless parameters
 function bind!(stmt::Stmt, values::Vector)
     nparams = sqlite3_bind_parameter_count(stmt.handle)
@@ -210,6 +202,15 @@ type Source <: IOSource # <: IO
         new(schema,stmt,status)
     end
 end
+
+include("UDF.jl")
+export @sr_str, @register, register
+
+type Table
+    db::DB
+    name::AbstractString
+end
+
 # function Base.open(table::Table)
 #     return open(table.db,"select * from $(table.name)")
 # end

--- a/src/SQLite.jl
+++ b/src/SQLite.jl
@@ -127,8 +127,9 @@ bind!(stmt::Stmt,i::Int,val::AbstractFloat)  = @CHECK stmt.db sqlite3_bind_doubl
 bind!(stmt::Stmt,i::Int,val::Int32)          = @CHECK stmt.db sqlite3_bind_int(stmt.handle,i,val)
 bind!(stmt::Stmt,i::Int,val::Int64)          = @CHECK stmt.db sqlite3_bind_int64(stmt.handle,i,val)
 bind!(stmt::Stmt,i::Int,val::NullType)       = @CHECK stmt.db sqlite3_bind_null(stmt.handle,i)
-bind!(stmt::Stmt,i::Int,val::AbstractString) = @CHECK stmt.db sqlite3_bind_text(stmt.handle,i,val)
+bind!(stmt::Stmt,i::Int,val::ASCIIString)    = @CHECK stmt.db sqlite3_bind_text(stmt.handle,i,val)
 bind!(stmt::Stmt,i::Int,val::UTF16String)    = @CHECK stmt.db sqlite3_bind_text16(stmt.handle,i,val)
+bind!(stmt::Stmt,i::Int,val::AbstractString) = @CHECK stmt.db sqlite3_bind_text16(stmt.handle,i,utf8(val))
 # We may want to track the new ByteVec type proposed at https://github.com/JuliaLang/julia/pull/8964
 # as the "official" bytes type instead of Vector{UInt8}
 bind!(stmt::Stmt,i::Int,val::Vector{UInt8})  = @CHECK stmt.db sqlite3_bind_blob(stmt.handle,i,val)

--- a/src/SQLite.jl
+++ b/src/SQLite.jl
@@ -187,7 +187,18 @@ type Source <: IOSource # <: IO
         status = SQLite.execute!(stmt)
         #TODO: build Schema
         cols = sqlite3_column_count(stmt.handle)
-        return DataStream(stmt,cols,status)
+        types = DataType[]
+        for i=1:cols
+            t = sqlite3_column_type(stmt.handle,i-1)
+            if t == SQLITE_INTEGER   push!(schema,Integer)
+            elseif t == SQLITE_FLOAT push!(schema,AbstractFloat)
+            elseif t == SQLITE_TEXT  push!(schema,AbstractString)
+            elseif t == SQLITE_BLOB  push!(schema,AbstractString) # encode blob as string
+            else                     push!(schema,Any)
+            end
+        end
+        schema = Schema(types)	
+        new(schema,stmt,status)
     end
 end
 # function Base.open(table::Table)

--- a/src/SQLite.jl
+++ b/src/SQLite.jl
@@ -93,7 +93,7 @@ end
 Stmt(db::DB, sql::AbstractString) = Stmt(db,utf8(sql))
 
 function Base.close(stmt::Stmt)
-    @CHECK stmt sqlite3_finalize(stmt.handle)
+    @CHECK stmt.db sqlite3_finalize(stmt.handle)
     nothing
 end
 

--- a/src/SQLite.jl
+++ b/src/SQLite.jl
@@ -187,7 +187,7 @@ type Source <: IOSource # <: IO
         status = SQLite.execute!(stmt)
         #TODO: build Schema
         cols = sqlite3_column_count(stmt.handle)
-        return Stream(stmt,cols,status)
+        return DataStream(stmt,cols,status)
     end
 end
 # function Base.open(table::Table)
@@ -199,9 +199,9 @@ function Base.eof(s::Source)
     return s.status == SQLITE_DONE
 end
 
-Base.start(s::Stream) = 1
-Base.done(s::Stream,col) = eof(s)
-function Base.next(s::Stream,i)
+Base.start(s::DataStream) = 1
+Base.done(s::DataStream,col) = eof(s)
+function Base.next(s::DataStream,i)
     t = sqlite3_column_type(s.stmt.handle,i-1)
     r::Any
     if t == SQLITE_INTEGER
@@ -229,7 +229,7 @@ function Base.next(s::Stream,i)
     return r, i
 end
 
-function Base.readline(s::Stream,delim::Char=',',buf::IOBuffer=IOBuffer())
+function Base.readline(s::DataStream,delim::Char=',',buf::IOBuffer=IOBuffer())
     eof(s) && return ""
     for i = 1:s.cols
         val = sqlite3_column_text(s.stmt.handle,i-1)

--- a/src/SQLite.jl
+++ b/src/SQLite.jl
@@ -1,7 +1,7 @@
 module SQLite
 
 using Compat
-# using CSV
+using CSV
 using Libz
 using DataStreams
 
@@ -159,8 +159,8 @@ function execute!(db::DB,sql::AbstractString)
     return changes(db)
 end
 
-type Source <: IOSource # <: IO
-    schema::Schema
+type Source <: Data.Source # <: IO
+    schema::Data.Schema
     stmt::Stmt
     status::Cint
     function Source(db::DB,sql::AbstractString, values=[])
@@ -179,7 +179,7 @@ type Source <: IOSource # <: IO
             else                     push!(types,Any)
             end
         end
-        schema = Schema(types)	
+        schema = Data.Schema(types)
         new(schema,stmt,status)
         # source = new(schema,stmt,status)
         # finalizer(source, close)    # do we need a finalizer here?

--- a/src/SQLite.jl
+++ b/src/SQLite.jl
@@ -84,13 +84,10 @@ type Stmt
 
     function Stmt(db::DB,sql::UTF8String)
         handlemem = [C_NULL]
-        if @OK sqliteprepare(db,sql,handlemem,[C_NULL])
-            stmt = new(db,handlemem[1])
-            finalizer(stmt, close)
-            return stmt
-        else
-            sqliteerror()
-        end
+        @CHECK db sqlite3_prepare_v2(db.handle,sql,handlemem,[C_NULL])
+        stmt = new(db,handlemem[1])
+        finalizer(stmt, close)
+        return stmt
     end
 end
 Stmt(db::DB, sql::AbstractString) = Stmt(db,utf8(sql))
@@ -99,9 +96,6 @@ function Base.close(stmt::Stmt)
     @CHECK stmt sqlite3_finalize(stmt.handle)
     nothing
 end
-
-sqliteprepare(db,sql,stmt,null) = @CHECK db sqlite3_prepare_v2(db.handle,utf8(sql),stmt,null)
-# sqliteprepare(db::DB{UTF16String},sql,stmt,null) = @CHECK db sqlite3_prepare16_v2(db.handle,utf16(sql),stmt,null)
 
 type Table
     db::DB

--- a/src/SQLite.jl
+++ b/src/SQLite.jl
@@ -63,7 +63,7 @@ DB() = DB(":memory:")
 Base.show(io::IO, db::SQLite.DB) = print(io, string("SQLite.DB(",db.file == ":memory:" ? "in-memory" : "\"$(db.file)\"",")"))
 
 function Base.close(db::DB)
-    @CHECK db sqlite3_close(db.handle)
+    db.handle==C_NULL || @CHECK db sqlite3_close(db.handle)
     db.handle = C_NULL # make sure released handle not reused
     nothing
 end
@@ -90,7 +90,7 @@ end
 Stmt(db::DB, sql::AbstractString) = Stmt(db,utf8(sql))
 
 function Base.close(stmt::Stmt)
-    @CHECK stmt.db sqlite3_finalize(stmt.handle)
+    stmt.handle==C_NULL || @CHECK stmt.db sqlite3_finalize(stmt.handle)
     stmt.handle = C_NULL # make sure released handle not reused
     nothing
 end

--- a/src/SQLite.jl
+++ b/src/SQLite.jl
@@ -68,7 +68,8 @@ DB() = DB(":memory:")
 Base.show(io::IO, db::SQLite.DB) = print(io, string("SQLite.DB(",db.file == ":memory:" ? "in-memory" : "\"$(db.file)\"",")"))
 
 function close(db::DB)
-    sqlite3_close(db.handle)
+    @CHECK sqlite3_close(db.handle)
+    nothing
 end
 
 function changes(db::DB)

--- a/src/SQLite.jl
+++ b/src/SQLite.jl
@@ -269,19 +269,19 @@ function Base.writecsv(db,table,file;compressed::Bool=false)
 end
 
 function query(db::DB,sql::AbstractString, values=[])
-    stream = SQLite.open(db,sql,values)
-    ncols = stream.cols
-    (eof(stream) || ncols == 0) && return changes(db)
+    source = Source(db,sql,values)
+    ncols = size(source.schema,2) 
+    (eof(source) || ncols == 0) && return changes(db)
     colnames = Array(AbstractString,ncols)
     results = Array(Any,ncols)
     for i = 1:ncols
-        colnames[i] = bytestring(sqlite3_column_name(stream.stmt.handle,i-1))
+        colnames[i] = bytestring(sqlite3_column_name(source.stmt.handle,i-1))
         results[i] = Any[]
     end
     col = 1
-    while !eof(stream)
+    while !eof(source)
         c = col
-        r, col = next(stream,col)
+        r, col = next(source,col)
         push!(results[c],r)
     end
     return ResultSet(colnames, results)

--- a/src/SQLite.jl
+++ b/src/SQLite.jl
@@ -64,6 +64,7 @@ Base.show(io::IO, db::SQLite.DB) = print(io, string("SQLite.DB(",db.file == ":me
 
 function Base.close(db::DB)
     @CHECK db sqlite3_close(db.handle)
+    db.handle = C_NULL # make sure released handle not reused
     nothing
 end
 
@@ -90,6 +91,7 @@ Stmt(db::DB, sql::AbstractString) = Stmt(db,utf8(sql))
 
 function Base.close(stmt::Stmt)
     @CHECK stmt.db sqlite3_finalize(stmt.handle)
+    stmt.handle = C_NULL # make sure released handle not reused
     nothing
 end
 

--- a/src/SQLite.jl
+++ b/src/SQLite.jl
@@ -1,7 +1,7 @@
 module SQLite
 
 using Compat
-using CSV
+# using CSV
 using Libz
 using DataStreams
 

--- a/src/SQLite.jl
+++ b/src/SQLite.jl
@@ -417,7 +417,7 @@ function readbind!{T<:AbstractString}(io,::Type{T},row,col,stmt)
     return
 end
 
-function create(db::DB,file::CSV.File,name::AbstractString=splitext(basename(file.fullpath))[1]
+function create(db::DB,file::CSV.Source,name::AbstractString=splitext(basename(file.fullpath))[1]
                 ;temp::Bool=false,ifnotexists::Bool=false)
     names = SQLite.make_unique([SQLite.identifier(i) for i in file.header])
     sqltypes = [string(names[i]) * SQLite.gettype(file.types[i]) for i = 1:file.cols]
@@ -462,7 +462,7 @@ function createindex(db::DB,table::AbstractString,index::AbstractString,cols
     return changes(db)
 end
 
-function append!(db::DB,name::AbstractString,file::CSV.File)
+function append!(db::DB,name::AbstractString,file::CSV.Source)
     N = transaction(db) do
         # insert statements
         params = chop(repeat("?,",file.cols))

--- a/src/SQLite.jl
+++ b/src/SQLite.jl
@@ -113,7 +113,7 @@ function bind!{V}(stmt::Stmt, values::Dict{Symbol, V})
         name = bytestring(sqlite3_bind_parameter_name(stmt.handle, i))
         @assert !isempty(name) "nameless parameters should be passed as a Vector"
         # name is returned with the ':', '@' or '$' at the start
-        name = name[2:end]
+        name = name[1]=='@' ? name : name[2:end]
         bind!(stmt, i, values[symbol(name)])
     end
 end

--- a/src/SQLite.jl
+++ b/src/SQLite.jl
@@ -128,8 +128,8 @@ bind!(stmt::Stmt,i::Int,val::Int32)          = @CHECK stmt.db sqlite3_bind_int(s
 bind!(stmt::Stmt,i::Int,val::Int64)          = @CHECK stmt.db sqlite3_bind_int64(stmt.handle,i,val)
 bind!(stmt::Stmt,i::Int,val::NullType)       = @CHECK stmt.db sqlite3_bind_null(stmt.handle,i)
 bind!(stmt::Stmt,i::Int,val::ASCIIString)    = @CHECK stmt.db sqlite3_bind_text(stmt.handle,i,val)
-bind!(stmt::Stmt,i::Int,val::UTF16String)    = @CHECK stmt.db sqlite3_bind_text16(stmt.handle,i,val)
-bind!(stmt::Stmt,i::Int,val::AbstractString) = @CHECK stmt.db sqlite3_bind_text16(stmt.handle,i,utf8(val))
+bind!(stmt::Stmt,i::Int,val::UTF8String)     = @CHECK stmt.db sqlite3_bind_text(stmt.handle,i,val)
+bind!(stmt::Stmt,i::Int,val::AbstractString) = @CHECK stmt.db sqlite3_bind_text(stmt.handle,i,utf8(val))
 # We may want to track the new ByteVec type proposed at https://github.com/JuliaLang/julia/pull/8964
 # as the "official" bytes type instead of Vector{UInt8}
 bind!(stmt::Stmt,i::Int,val::Vector{UInt8})  = @CHECK stmt.db sqlite3_bind_blob(stmt.handle,i,val)

--- a/src/serialize.jl
+++ b/src/serialize.jl
@@ -1,0 +1,29 @@
+
+# internal wrapper type to, in-effect, mark something which has been serialized
+immutable Serialization
+    object
+end
+
+function sqlserialize(x)
+    t = IOBuffer()
+    # deserialize will sometimes return a random object when called on an array
+    # which has not been previously serialized, we can use this type to check
+    # that the array has been serialized
+    s = Serialization(x)
+    serialize(t,s)
+    return takebuf_array(t)
+end
+
+const SERIALIZATION = UInt8[0x11,0x01,0x02,0x0d,0x53,0x65,0x72,0x69,0x61,0x6c,0x69,0x7a,0x61,0x74,0x69,0x6f,0x6e,0x23]
+function sqldeserialize(r)
+    ret = ccall(:memcmp, Int32, (Ptr{UInt8},Ptr{UInt8}, UInt),
+            SERIALIZATION, r, min(18,length(r)))
+
+    if ret == 0
+        v = deserialize(IOBuffer(r))
+        return v.object
+    else
+        return r
+    end
+end
+

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -16,6 +16,17 @@ db = SQLite.DB(temp)
 close(db)
 @test isfile(temp)
 
+# test construction of new statement
+db = SQLite.DB()
+stmt = SQLite.Stmt(db,"SELECT 1+1;")
+finalize(stmt)
+
+stmt = SQLite.Stmt(db,"SELECT 2+2;")
+close(stmt)
+
+# test construction of statement with error
+@test_throws stmt = SQLite.Stmt(db,"SAYLEKT 3+3;")
+
 #db = SQLite.DB("/Users/jacobquinn/.julia/v0.4/SQLite/test/Chinook_Sqlite.sqlite")
 db = SQLite.DB(joinpath(dirname(@__FILE__),"Chinook_Sqlite.sqlite"))
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,5 +1,10 @@
-using Base.Test, Compat#, SQLite
-reload("/Users/jacobquinn/.julia/v0.4/SQLite/src/SQLite.jl")
+using Base.Test
+using Compat 
+if !isdefined(:SQLite)
+    using SQLite
+else
+    reload("SQLite")
+end
 
 a = SQLite.DB()
 finalize(a)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -6,11 +6,15 @@ else
     reload("SQLite")
 end
 
-a = SQLite.DB()
+# test open memory DB and finalizer
+db = SQLite.DB()
 finalize(a)
 
+# test create new file DB and closing
 temp = tempname()
-SQLite.DB(temp)
+db = SQLite.DB(temp)
+close(db)
+@test isfile(temp)
 
 #db = SQLite.DB("/Users/jacobquinn/.julia/v0.4/SQLite/test/Chinook_Sqlite.sqlite")
 db = SQLite.DB(joinpath(dirname(@__FILE__),"Chinook_Sqlite.sqlite"))

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -163,14 +163,15 @@ if VERSION > v"0.4.0-"
     SQLite.query(db,"CREATE TABLE temp AS SELECT * FROM Album")
     r = SQLite.query(db, "SELECT * FROM temp LIMIT :a", Dict(:a => 3))
     @test size(r) == (3,3)
-    r = SQLite.query(db, "SELECT * FROM temp WHERE Title LIKE @word", Dict(:word => "%time%"))
+    r = SQLite.query(db, "SELECT * FROM temp WHERE Title LIKE @word", Dict(symbol("@word") => "%time%"))
     @test r.values[1] == [76, 111, 187]
-    SQLite.query(db, "INSERT INTO temp VALUES (@lid, :title, \$rid)", Dict(:rid => 0, :lid => 0, :title => "Test Album"))
+    SQLite.query(db, "INSERT INTO temp VALUES (@lid, :title, \$rid)", Dict(:rid => 0, symbol("@lid") => 0, :title => "Test Album"))
     r = SQLite.query(db, "SELECT * FROM temp WHERE AlbumId = 0")
     @test r == SQLite.ResultSet(Any["AlbumId", "Title", "ArtistId"], Any[Any[0], Any["Test Album"], Any[0]])
     SQLite.drop!(db, "temp")
 end
 
+SQLite.register(db,SQLite.regexp,nargs=2,name="REGEXP")
 r = SQLite.query(db, sr"SELECT LastName FROM Employee WHERE BirthDate REGEXP '^\d{4}-08'")
 @test r.values[1][1] == "Peacock"
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -28,6 +28,7 @@ close(stmt)
 
 # test construction of statement with error
 @test_throws SQLite.SQLiteException stmt = SQLite.Stmt(binddb,"SAYLEKT 3+3;")
+close(stmt)
 
 # test execute!(DB,AbstractString)
 res = SQLite.execute!(binddb,"CREATE TABLE t2 (i INT, f REAL, s TEXT, a BLOB)")
@@ -43,6 +44,7 @@ SQLite.execute!(stmt)
 SQLite.bind!(stmt,[0,1.0,"missing",2//1])
 SQLite.bind!(stmt,[3,Inf,"world",2//3])
 SQLite.execute!(stmt)
+close(stmt)
 
 # test binding using dictionary
 stmt = SQLite.Stmt(binddb,"INSERT INTO t2 VALUES (:p1, \$param::two, @p3, :p4)")
@@ -67,6 +69,7 @@ src = SQLite.Source(binddb,"SELECT * FROM t2 WHERE s='world' ;")
 v = collect(src)
 @test length(v)==8
 @test map(typeof,v)==DataType[ Int64, Float64, ASCIIString, Complex{Float64}, Int64, Float64, ASCIIString, Rational{Int64} ]
+close(src)
 
 # test execute!(Stmt)
 stmt = SQLite.Stmt(binddb,"DROP TABLE t2")
@@ -80,6 +83,7 @@ results = SQLite.query(db,"SELECT name FROM sqlite_master WHERE type='table';")
 @test length(results.colnames) == 1
 @test results.colnames[1] == "name"
 @test size(results) == (11,1)
+close(binddb)
 
 results1 = SQLite.tables(db)
 @test results.colnames == results1.colnames
@@ -202,7 +206,7 @@ end
 for (v1, v2) in zip(r.values[2], Any[b"b", BigInt(2), p1, p2])
     @test v1 == v2
 end
-finalize(binddb)
+close(binddb)
 
 # I can't be arsed to create a new one using old dictionary syntax
 if VERSION > v"0.4.0-"
@@ -311,7 +315,7 @@ SQLite.drop!(db2, "nonexistant", ifexists=true)
 SQLite.drop!(db2, "tab2", ifexists=true)
 @test !in("tab2", SQLite.tables(db2)[1])
 
-finalize(db2)
+close(db2)
 
 @test size(SQLite.tables(db)) == (11,1)
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -25,7 +25,7 @@ stmt = SQLite.Stmt(db,"SELECT 2+2;")
 close(stmt)
 
 # test construction of statement with error
-@test_throws stmt = SQLite.Stmt(db,"SAYLEKT 3+3;")
+@test_throws SQLite.SQLiteException stmt = SQLite.Stmt(db,"SAYLEKT 3+3;")
 
 #db = SQLite.DB("/Users/jacobquinn/.julia/v0.4/SQLite/test/Chinook_Sqlite.sqlite")
 db = SQLite.DB(joinpath(dirname(@__FILE__),"Chinook_Sqlite.sqlite"))


### PR DESCRIPTION
hi SQLite.jl-ers,

when trying to parse a CSV into SQLite using the jq/updates branch, several problems emerged, at least, on my release-0.4 julia. having fixed most of them, the SQLite package now passes the tests for me.
this pull request is a collection of small changes (or can be viewed as one large diff), which adds some code (to the runtests mainly and close functions for SQLite types), refactors a bit (move serialize to separate file) and even fixes a bug or two (parsing @ parameter names from sqlite3).

hope this helps the maturation of the package. 