### PR TITLE
retain @ in @ named parameters.

### DIFF
--- a/src/SQLite.jl
+++ b/src/SQLite.jl
@@ -108,7 +108,7 @@ function bind!{V}(stmt::Stmt, values::Dict{Symbol, V})
         name = bytestring(sqlite3_bind_parameter_name(stmt.handle, i))
         @assert !isempty(name) "nameless parameters should be passed as a Vector"
         # name is returned with the ':', '@' or '$' at the start
-        name = name[2:end]
+        name = name[1]=='@' ? name : name[2:end]
         bind!(stmt, i, values[symbol(name)])
     end
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -146,9 +146,9 @@ end
 SQLite.query(db,"CREATE TABLE temp AS SELECT * FROM Album")
 r = SQLite.query(db, "SELECT * FROM temp LIMIT :a", Dict(:a => 3))
 @test size(r) == (3,3)
-r = SQLite.query(db, "SELECT * FROM temp WHERE Title LIKE @word", Dict(:word => "%time%"))
+r = SQLite.query(db, "SELECT * FROM temp WHERE Title LIKE @word", Dict(symbol("@word") => "%time%"))
 @test [get(i) for i in r.data[1]] == [76, 111, 187]
-SQLite.query(db, "INSERT INTO temp VALUES (@lid, :title, \$rid)", Dict(:rid => 0, :lid => 0, :title => "Test Album"))
+SQLite.query(db, "INSERT INTO temp VALUES (@lid, :title, \$rid)", Dict(:rid => 0, symbol("@lid") => 0, :title => "Test Album"))
 r = SQLite.query(db, "SELECT * FROM temp WHERE AlbumId = 0")
 @test r[1,1] === Nullable(0)
 @test get(r[1,2]) == "Test Album"


### PR DESCRIPTION
According to the SQLite C API the `@` remains in the parameter name (this is the difference from `$` parameters). To strip it is possible but it's a choice to diverge from the C API.