### PR TITLE
escape identifiers in SQL statements

### DIFF
--- a/src/SQLite.jl
+++ b/src/SQLite.jl
@@ -187,12 +187,11 @@ function execute!(db::DB,sql::AbstractString)
     return execute!(stmt)
 end
 
-"Escape SQLite identifiers (e.g. column, table or index names). Can be either a string, or a vector of strings (note does not check for null characters)."
+"Escape SQLite identifiers (e.g. column, table or index names). Can be either
+a string, or a vector of strings (note does not check for null characters).
+A vector of identifiers will be separated by commas."
 esc_id(x::AbstractString) = "\""*replace(x,"\"","\"\"")*"\""
 esc_id{S<:AbstractString}(X::AbstractVector{S}) = join(map(esc_id,X),',')
-
-"Escape SQLite string constants (note does not check for null characters)."
-esc_str(x::AbstractString) = "'"*replace(x,"'","''")*"'"
 
 
 # Transaction-based commands

--- a/src/Source.jl
+++ b/src/Source.jl
@@ -132,9 +132,10 @@ function query(db::DB,sql::AbstractString, values=[];rows::Int=0,stricttypes::Bo
     so = Source(db,sql,values;rows=rows,stricttypes=stricttypes)
     return Data.stream!(so,Data.Table)
 end
+
 "returns a list of tables in `db`"
 tables(db::DB) = query(db,"SELECT name FROM sqlite_master WHERE type='table';")
 "returns a list of indices in `db`"
 indices(db::DB) = query(db,"SELECT name FROM sqlite_master WHERE type='index';")
 "returns a list of columns in `table`"
-columns(db::DB,table::AbstractString) = query(db,"pragma table_info($table)")
+columns(db::DB,table::AbstractString) = query(db,"PRAGMA table_info($(esc_id(table)))")


### PR DESCRIPTION
Defines `esc_id` and `esc_str` (currently unused) for escaping identifiers in SQL queries. I've only updated the new interface so far.