### PR TITLE
Fix errors and deprecation warnings

### DIFF
--- a/REQUIRE
+++ b/REQUIRE
@@ -3,3 +3,5 @@ BinDeps
 @osx Homebrew
 @windows WinRPM
 DataStreams
+Compat
+LegacyStrings

--- a/deps/build.jl
+++ b/deps/build.jl
@@ -1,21 +1,19 @@
 using BinDeps
+using Compat
 
 @BinDeps.setup
 
 sqlite3_lib = library_dependency("sqlite3_lib", aliases = ["sqlite3","sqlite3-64","libsqlite3","libsqlite3-0"])
 
-@windows_only begin
+if is_windows()
     using WinRPM
     provides(WinRPM.RPM, "libsqlite3-0",sqlite3_lib, os = :Windows)
-end
-
-@osx_only begin
-  using Homebrew
-  provides(Homebrew.HB, "sqlite", sqlite3_lib, os = :Darwin)
-end
-@unix_only begin
-  provides(Yum, Dict("sqlite3-devel" => sqlite3_lib))
-  provides(AptGet, Dict("sqlite3" => sqlite3_lib))
+elseif is_apple()
+    using Homebrew
+    provides(Homebrew.HB, "sqlite", sqlite3_lib, os = :Darwin)
+elseif is_linux()
+    provides(Yum, Dict("sqlite3-devel" => sqlite3_lib))
+    provides(AptGet, Dict("sqlite3" => sqlite3_lib))
 end
 
 @BinDeps.install Dict(:sqlite3_lib => :sqlite3_lib)

--- a/src/SQLite.jl
+++ b/src/SQLite.jl
@@ -2,6 +2,7 @@ VERSION >= v"0.4.0-dev+6521" && __precompile__(true)
 module SQLite
 
 using DataStreams, DataFrames, WeakRefStrings, LegacyStrings
+import LegacyStrings: UTF16String
 
 export Data, DataFrame
 


### PR DESCRIPTION
There were errors caused by `using LegacyStrings` without having LegacyStrings in the REQUIRE. I also fixed the deprecation warnings for the OS checking blocks.