### PR TITLE
Added sqlite_open_v2 functionality with ability to use open flags

### DIFF
--- a/src/api.jl
+++ b/src/api.jl
@@ -19,6 +19,11 @@ function sqlite3_open16(file::UTF16String,handle)
         Cint, (Ptr{UInt16},Ptr{Void}),
         file,handle)
 end
+function sqlite3_open_v2(file::AbstractString,handle,flags::Cint,vfs::Union{Ptr{Void},AbstractString}=C_NULL)
+    return ccall( (:sqlite3_open_v2, sqlite3_lib),
+            Cint, (Ptr{UInt8},Ptr{Void},Cint,Ptr{UInt8}),
+            file,handle,flags,vfs)
+end
 function sqlite3_close(handle::Ptr{Void})
     @NULLCHECK handle
     return ccall( (:sqlite3_close, sqlite3_lib),
@@ -446,11 +451,6 @@ end
 # SQLITE_API int sqlite3_db_status(sqlite3*, int op, int *pCur, int *pHiwtr, int resetFlg);
 
 # Not directly used
-function sqlite3_open_v2(file::AbstractString,handle,flags::Cint,vfs::AbstractString)
-    return ccall( (:sqlite3_open_v2, sqlite3_lib),
-            Cint, (Ptr{UInt8},Ptr{Void},Cint,Ptr{UInt8}),
-            file,handle,flags,vfs)
-end
 function sqlite3_prepare(handle::Ptr{Void},query::AbstractString,stmt,unused)
     @NULLCHECK handle
     return ccall( (:sqlite3_prepare, sqlite3_lib),

--- a/src/consts.jl
+++ b/src/consts.jl
@@ -135,7 +135,7 @@ const SQLITE_CONFIG_HEAP =           8 #  /* void*, int nByte, int min */
 const SQLITE_CONFIG_MEMSTATUS =      9 #  /* boolean */
 const SQLITE_CONFIG_MUTEX =         10 #  /* sqlite3_mutex_methods* */
 const SQLITE_CONFIG_GETMUTEX =      11 #  /* sqlite3_mutex_methods* */
-#/* previously SQLITE_CONFIG_CHUNKALLOC 12 which is now unused. */ 
+#/* previously SQLITE_CONFIG_CHUNKALLOC 12 which is now unused. */
 const SQLITE_CONFIG_LOOKASIDE =     13 #  /* int int */
 const SQLITE_CONFIG_PCACHE =        14 #  /* no-op */
 const SQLITE_CONFIG_GETPCACHE =     15 #  /* no-op */
@@ -302,3 +302,14 @@ const SQLITE_TESTCTRL_LAST =                     19 #
 
 #Virtual Table Configuration Options
 const SQLITE_VTAB_CONSTRAINT_SUPPORT =  1 #
+
+#Flags for sqlite3_open_v2
+const SQLITE_OPEN_READONLY =                    1
+const SQLITE_OPEN_READWRITE =                   2
+const SQLITE_OPEN_CREATE =                      4
+const SQLITE_OPEN_URI =                        40
+const SQLITE_OPEN_MEMORY =                     80
+const SQLITE_OPEN_NOMUTEX =                  8000
+const SQLITE_OPEN_FULLMUTEX =               10000
+const SQLITE_OPEN_SHAREDCACHE =             20000
+const SQLITE_OPEN_PRIVATECACHE =            40000


### PR DESCRIPTION
- Added the open constants
- Changed the DB constructer to take a keyword argument `flags` (as `Array`)

I mainly wanted to be able to open databases thread-safe. Everything appears to be working on my end. Let me know if you want me to tweak anything.