### PR TITLE
see if avoiding double-finalizing fixes win32 access violation

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,8 +40,8 @@ Contributions are very welcome, as are feature requests and suggestions. Please 
 [travis-img]: https://travis-ci.org/JuliaDB/SQLite.jl.svg?branch=master
 [travis-url]: https://travis-ci.org/JuliaDB/SQLite.jl
 
-[appveyor-img]: https://ci.appveyor.com/api/projects/status/h227adt6ovd1u3sx/branch/master?svg=true
-[appveyor-url]: https://ci.appveyor.com/project/JuliaDB/documenter-jl/branch/master
+[appveyor-img]: https://ci.appveyor.com/api/projects/status/github/JuliaDB/SQLite.jl?branch=master&svg=true
+[appveyor-url]: https://ci.appveyor.com/project/quinnj/sqlite-jl/branch/master
 
 [codecov-img]: https://codecov.io/gh/JuliaDB/SQLite.jl/branch/master/graph/badge.svg
 [codecov-url]: https://codecov.io/gh/JuliaDB/SQLite.jl

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -34,6 +34,7 @@ build_script:
   - IF EXIST .git\shallow (git fetch --unshallow)
   - C:\projects\julia\bin\julia -e "versioninfo();
       Pkg.clone(pwd(), \"SQLite\"); Pkg.build(\"SQLite\")"
+  - where *sqlite3*
 
 test_script:
   - C:\projects\julia\bin\julia -e "Pkg.test(\"SQLite\")"

--- a/src/SQLite.jl
+++ b/src/SQLite.jl
@@ -54,7 +54,7 @@ end
 DB() = DB(":memory:")
 
 function _close(db::DB)
-    sqlite3_close_v2(db.handle)
+    db.handle == C_NULL || sqlite3_close_v2(db.handle)
     db.handle = C_NULL
     return
 end
@@ -78,7 +78,7 @@ type Stmt
 end
 
 function _close(stmt::Stmt)
-    sqlite3_finalize(stmt.handle)
+    stmt.handle == C_NULL || sqlite3_finalize(stmt.handle)
     stmt.handle = C_NULL
     return
 end


### PR DESCRIPTION
given the presence of the `@NULLCHECK` macros I don't see why this would change anything, but I might be missing something